### PR TITLE
feat: re-process old downloads to get page_count and text formatting

### DIFF
--- a/bandc/apps/agenda/admin.py
+++ b/bandc/apps/agenda/admin.py
@@ -3,7 +3,6 @@ from django.utils.html import format_html
 from django_object_actions import DjangoObjectActions
 
 from .models import BandC, Meeting, Document
-from .tasks import get_details_from_pdf
 
 
 @admin.register(BandC)
@@ -37,7 +36,7 @@ class DocumentAdmin(DjangoObjectActions, admin.ModelAdmin):
     list_filter = ("scrape_status", "type")
     raw_id_fields = ("meeting",)
 
-    def pdf(self, request, obj: Document):
-        get_details_from_pdf(obj.pk)
+    # def pdf(self, request, obj: Document):
+    #     get_details_from_pdf(obj.pk)
 
     objectactions = ("pdf",)

--- a/bandc/apps/agenda/admin.py
+++ b/bandc/apps/agenda/admin.py
@@ -36,7 +36,7 @@ class DocumentAdmin(DjangoObjectActions, admin.ModelAdmin):
     list_filter = ("scrape_status", "type")
     raw_id_fields = ("meeting",)
 
-    # def pdf(self, request, obj: Document):
-    #     get_details_from_pdf(obj.pk)
+    def pdf(self, request, obj: Document):
+        obj.refresh()
 
     objectactions = ("pdf",)

--- a/bandc/apps/agenda/management/commands/scrape_cron.py
+++ b/bandc/apps/agenda/management/commands/scrape_cron.py
@@ -16,7 +16,9 @@ class Command(BaseCommand):
         if qs.exists():
             doc = qs[0]
             doc.refresh()
-            self.stdout.write(f'Re-scraped "{doc}", {qs.count()} left')
+            self.stdout.write(
+                f'Re-scraped "{doc}" {doc.get_absolute_url()}, {qs.count()} left'
+            )
         else:
             self.stdout.write(
                 "No more missing Document.page_count we can delete the migration"

--- a/bandc/apps/agenda/management/commands/scrape_cron.py
+++ b/bandc/apps/agenda/management/commands/scrape_cron.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from bandc.apps.agenda.models import BandC
+from bandc.apps.agenda.models import BandC, Document
 
 
 class Command(BaseCommand):
@@ -11,3 +11,13 @@ class Command(BaseCommand):
         bandc = queryset[0]
         bandc.pull()
         self.stdout.write(self.style.SUCCESS(f'Scraped "{bandc}"'))
+
+        qs = Document.objects.filter(page_count=None).exclude(thumbnail="")
+        if qs.exists():
+            doc = qs[0]
+            doc.refresh()
+            self.stdout.write(f'Re-scraped "{doc}", {qs.count()} left')
+        else:
+            self.stdout.write(
+                "No more missing Document.page_count we can delete the migration"
+            )

--- a/bandc/apps/agenda/models.py
+++ b/bandc/apps/agenda/models.py
@@ -192,4 +192,6 @@ class Document(models.Model):
 
     def refresh(self) -> None:
         """Re-download and regenerate thumbnail and data"""
-        pass
+        from .pdf import process_pdf
+
+        process_pdf(self)

--- a/bandc/apps/agenda/models.py
+++ b/bandc/apps/agenda/models.py
@@ -189,3 +189,7 @@ class Document(models.Model):
             return self.text
 
         return bad_chars.sub("", self.text)
+
+    def refresh(self) -> None:
+        """Re-download and regenerate thumbnail and data"""
+        pass

--- a/bandc/apps/agenda/pdf.py
+++ b/bandc/apps/agenda/pdf.py
@@ -15,12 +15,16 @@ BASE_PATH = "/tmp/bandc_pdfs/"  # TODO settings
 logger = logging.getLogger(__name__)
 
 
-def pdf_file_path(document: Document) -> str:
+def _download_document_pdf(document: Document) -> str:
     """
     Downloads the pdf locally and return the path it.
 
     We have to download the file to the disk because it's the easiest way to
     send the pdf to ImageMagick.
+
+    Returns
+    -------
+    The path to the downloaded pdf
     """
     if not os.path.isdir(BASE_PATH):
         os.makedirs(BASE_PATH)
@@ -37,7 +41,7 @@ def pdf_file_path(document: Document) -> str:
     return final_filepath
 
 
-def pdf_page_count(filepath: str) -> int:
+def _get_pdf_page_count(filepath: str) -> int:
     with open(filepath, "rb") as fp:
         return len(list(PDFPage.get_pages(fp, set())))
 
@@ -63,11 +67,11 @@ def process_pdf(document: Document):
         document.save()
         return
 
-    filepath = pdf_file_path(document)
+    filepath = _download_document_pdf(document)
     try:
         document.text = extract_text(filepath).strip()
         document.scrape_status = "scraped"
-        document.page_count = pdf_page_count(filepath)
+        document.page_count = _get_pdf_page_count(filepath)
     except (
         PDFTextExtractionNotAllowed,
         PDFEncryptionError,

--- a/bandc/apps/agenda/tasks.py
+++ b/bandc/apps/agenda/tasks.py
@@ -1,12 +1,6 @@
 from .models import BandC, Document
-from .pdf import process_pdf
 
 
 def pull(bandc_pk: int):
     band = BandC.objects.get(pk=bandc_pk)
     band.pull()
-
-
-def get_details_from_pdf(doc_pk: int):
-    doc = Document.objects.get(pk=doc_pk)
-    process_pdf(doc)

--- a/bandc/apps/agenda/tasks.py
+++ b/bandc/apps/agenda/tasks.py
@@ -1,6 +1,0 @@
-from .models import BandC, Document
-
-
-def pull(bandc_pk: int):
-    band = BandC.objects.get(pk=bandc_pk)
-    band.pull()

--- a/bandc/apps/agenda/tests/test_pdf.py
+++ b/bandc/apps/agenda/tests/test_pdf.py
@@ -1,15 +1,15 @@
 import os
 import unittest
 
-from ..pdf import pdf_page_count
+from ..pdf import _get_pdf_page_count
 
 
 BASE_DIR = os.path.dirname(__file__)
 
 
 class PdfTest(unittest.TestCase):
-    def test_pdf_page_count(self):
+    def test_get_pdf_page_count(self):
         filepath = os.path.join(
             BASE_DIR, "samples/document_53B86715-0261-C36F-8C2F847EF15AD639.pdf"
         )
-        self.assertEqual(pdf_page_count(filepath), 5)
+        self.assertEqual(_get_pdf_page_count(filepath), 5)

--- a/bandc/apps/agenda/tests/test_utils.py
+++ b/bandc/apps/agenda/tests/test_utils.py
@@ -46,7 +46,7 @@ class UtilsTests(TestCase):
         html = open(os.path.join(BASE_DIR, "samples/parks.html")).read()
         self.assertEqual(get_number_of_pages(html), 2)
 
-    @mock.patch("bandc.apps.agenda.utils.get_details_from_pdf")
+    @mock.patch("bandc.apps.agenda.utils.process_pdf")
     def test_save_page_works(self, mock_task):
         html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
         meeting_data, doc_data = process_page(html)

--- a/bandc/apps/agenda/tests/test_utils.py
+++ b/bandc/apps/agenda/tests/test_utils.py
@@ -46,7 +46,7 @@ class UtilsTests(TestCase):
         html = open(os.path.join(BASE_DIR, "samples/parks.html")).read()
         self.assertEqual(get_number_of_pages(html), 2)
 
-    @mock.patch("bandc.apps.agenda.utils.process_pdf")
+    @mock.patch("bandc.apps.agenda.models.Document.refresh")
     def test_save_page_works(self, mock_task):
         html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
         meeting_data, doc_data = process_page(html)

--- a/bandc/apps/agenda/utils.py
+++ b/bandc/apps/agenda/utils.py
@@ -8,7 +8,6 @@ from lxml.html import document_fromstring
 from obj_update import obj_update_or_create
 
 from .models import BandC, Meeting, Document
-from .pdf import process_pdf
 
 
 # CONSTANTS
@@ -139,10 +138,10 @@ def save_page(meeting_data, doc_data, bandc: BandC) -> bool:
             except KeyError:
                 pass
         if True and doc.scrape_status == "toscrape":
-            process_pdf(doc)
+            doc.refresh()
 
     # Look for stale documents
-    stale_documents: List[Meeting] = []
+    stale_documents: List[str] = []
     for meeting in meetings.values():
         stale_documents.extend(meeting["docs"])
 

--- a/bandc/apps/agenda/utils.py
+++ b/bandc/apps/agenda/utils.py
@@ -8,7 +8,7 @@ from lxml.html import document_fromstring
 from obj_update import obj_update_or_create
 
 from .models import BandC, Meeting, Document
-from .tasks import get_details_from_pdf
+from .pdf import process_pdf
 
 
 # CONSTANTS
@@ -139,7 +139,7 @@ def save_page(meeting_data, doc_data, bandc: BandC) -> bool:
             except KeyError:
                 pass
         if True and doc.scrape_status == "toscrape":
-            get_details_from_pdf(doc.pk)
+            process_pdf(doc)
 
     # Look for stale documents
     stale_documents: List[Meeting] = []


### PR DESCRIPTION
```
$ ./manage.py scrape_cron
INFO bandc.apps.agenda.utils save_page Animal Advisory Commission
Scraped "Animal Advisory Commission"
INFO bandc.apps.agenda.pdf Downloading 2020-01-22: http://www.austintexas.gov/edims/document.cfm?id=334246
INFO bandc.apps.agenda.pdf Converting pdf: /tmp/bandc_pdfs/334246.pdf
Re-scraped "4b: Upper Dam Project Update" /parks-and-recreation-board/991/, 1293 left
```
Then visit http://localhost:8000/parks-and-recreation-board/991/ to see that the document has text formatting and a page count.