### PR TITLE
feat: split scrapers into separate commands

### DIFF
--- a/bandc/apps/agenda/management/commands/scrape_old.py
+++ b/bandc/apps/agenda/management/commands/scrape_old.py
@@ -8,14 +8,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         qs = Document.objects.filter(page_count=None).exclude(thumbnail="")
-        if qs.exists():
-            doc = qs[0]
-            self.stdout.write(f"Examining {doc.scrape_status} {doc}...")
-            doc.refresh()
-            self.stdout.write(
-                f'Re-scraped "{doc}" {doc.get_absolute_url()}, {qs.count()} left'
-            )
-        else:
+        if not qs.exists():
             self.stdout.write(
                 "No more missing Document.page_count we can delete the migration"
             )
+
+        doc = qs[0]
+        self.stdout.write(f"Examining {doc.scrape_status} {doc}...")
+        doc.refresh()
+        self.stdout.write(
+            f'Re-scraped "{doc}" {doc.get_absolute_url()}, {qs.count()} left'
+        )

--- a/bandc/apps/agenda/management/commands/scrape_old.py
+++ b/bandc/apps/agenda/management/commands/scrape_old.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from bandc.apps.agenda.models import BandC, Document
+from bandc.apps.agenda.models import Document
 
 
 class Command(BaseCommand):

--- a/bandc/apps/agenda/management/commands/scrape_old.py
+++ b/bandc/apps/agenda/management/commands/scrape_old.py
@@ -4,17 +4,13 @@ from bandc.apps.agenda.models import BandC, Document
 
 
 class Command(BaseCommand):
-    help = "Special version of 'scrape' for scraping one at a time in a cron job"
+    help = "Special version of 'scrape' for re-scraping an old document"
 
     def handle(self, *args, **options):
-        queryset = BandC.objects.filter(scrapable=True).order_by("scraped_at")
-        bandc = queryset[0]
-        bandc.pull()
-        self.stdout.write(self.style.SUCCESS(f'Scraped "{bandc}"'))
-
         qs = Document.objects.filter(page_count=None).exclude(thumbnail="")
         if qs.exists():
             doc = qs[0]
+            self.stdout.write(f"Examining {doc.scrape_status} {doc}...")
             doc.refresh()
             self.stdout.write(
                 f'Re-scraped "{doc}" {doc.get_absolute_url()}, {qs.count()} left'

--- a/bandc/apps/agenda/management/commands/scrape_one.py
+++ b/bandc/apps/agenda/management/commands/scrape_one.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from bandc.apps.agenda.models import BandC, Document
+from bandc.apps.agenda.models import BandC
 
 
 class Command(BaseCommand):

--- a/bandc/apps/agenda/management/commands/scrape_one.py
+++ b/bandc/apps/agenda/management/commands/scrape_one.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from bandc.apps.agenda.models import BandC, Document
+
+
+class Command(BaseCommand):
+    help = "Special version of 'scrape' for scraping one at a time in a cron job"
+
+    def handle(self, *args, **options):
+        queryset = BandC.objects.filter(scrapable=True).order_by("scraped_at")
+        bandc = queryset[0]
+        bandc.pull()
+        self.stdout.write(self.style.SUCCESS(f'Scraped "{bandc}"'))

--- a/bandc/apps/agenda/pdf.py
+++ b/bandc/apps/agenda/pdf.py
@@ -27,7 +27,7 @@ def extract_text(
     codec="utf-8",
     laparams=None,
     check_extractable=True,
-):
+) -> str:
     """Parse and return the text contained in a PDF file.
 
     Forked version of
@@ -101,7 +101,7 @@ def _grab_pdf_thumbnail(filepath: str) -> bytes:
     return out.stdout
 
 
-def process_pdf(document: Document):
+def process_pdf(document: Document) -> None:
     if not document.edims_id:
         document.scrape_status = "unscrapable"
         document.save()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-object-actions==2.0.0
 django==3.0.2
 idna==2.8                 # via requests
 lxml==4.4.2
-pdfminer.six==20200104
+pdfminer.six==20200121
 pillow==7.0.0
 project-runpy==1.0.1
 pycryptodome==3.9.4       # via pdfminer.six
@@ -26,5 +26,5 @@ sh==1.12.14
 six==1.14.0               # via django-extensions, python-dateutil
 sortedcontainers==2.1.0   # via pdfminer.six
 sqlparse==0.3.0           # via django
-urllib3==1.25.7           # via requests
+urllib3==1.25.8           # via requests
 waitress==1.4.2


### PR DESCRIPTION
There's a crazy issue with rotated pdfs that makes them very hard to turn into text. So hard that my VPS runs out of memory. By splitting them up, I can separate regular scraping from fixing old scrapes.