### PR TITLE
feat: change CI to use docker to test so imagemagic is consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-      - run: sudo apt update && sudo apt install -y imagemagick
-      - run: uv sync --all-extras --dev
-      - run: uv run make test
+      - run: docker build --target test -t crccheck/atx-bandc:test .
+      - run: make docker/test

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: ## Run test suite
 tdd: ## Run test watcher
 	LOG_LEVEL=$${LOG_LEVEL:-CRITICAL} nodemon -e py -x "python manage.py test --failfast --keepdb ${SCOPE}"
 
-docker/build: ## Build a local dev Docker image
+docker/build: ## Build a local dev Docker images
 docker/build: requirements.txt
 	cp .gitignore .dockerignore
 	docker buildx build --load --target production -t ${IMAGE} --build-arg GIT_SHA=$(shell git rev-parse HEAD) .
@@ -53,7 +53,7 @@ docker/build: requirements.txt
 docker/publish: ## Build the Docker image
 docker/publish: requirements.txt
 	cp .gitignore .dockerignore
-	docker buildx build --platform linux/amd64 --build-arg GIT_SHA=$(shell git rev-parse HEAD) --push -t crccheck/atx-bandc --build-arg GIT_SHA=$(shell git rev-parse HEAD) .
+	docker buildx build --platform --target production linux/amd64 --build-arg GIT_SHA=$(shell git rev-parse HEAD) --push -t crccheck/atx-bandc --build-arg GIT_SHA=$(shell git rev-parse HEAD) .
 
 docker/scrape: ## Scrape and process pdfs
 	docker run --rm ${IMAGE} python manage.py scrape
@@ -75,7 +75,7 @@ docker/converttest: ## Make sure we can create thumbnails from PDFs in productio
 	-flatten \
 	jpg:- > docker-converttest.jpg
 
-docker/test:
+docker/test: ## Run tests in our Docker container
 	docker run --rm crccheck/atx-bandc:test .venv/bin/python manage.py test
 
 docker/bash:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ tdd: ## Run test watcher
 docker/build: ## Build a local dev Docker image
 docker/build: requirements.txt
 	cp .gitignore .dockerignore
-	docker buildx build --load -t ${IMAGE} --build-arg GIT_SHA=$(shell git rev-parse HEAD) .
+	docker buildx build --load --target production -t ${IMAGE} --build-arg GIT_SHA=$(shell git rev-parse HEAD) .
+	docker buildx build --load --target test -t crccheck/atx-bandc:test .
 
 docker/publish: ## Build the Docker image
 docker/publish: requirements.txt
@@ -73,6 +74,9 @@ docker/converttest: ## Make sure we can create thumbnails from PDFs in productio
 	-thumbnail 400x400 \
 	-flatten \
 	jpg:- > docker-converttest.jpg
+
+docker/test:
+	docker run --rm crccheck/atx-bandc:test .venv/bin/python manage.py test
 
 docker/bash:
 	docker run --rm -it ${IMAGE} /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ docker/converttest: ## Make sure we can create thumbnails from PDFs in productio
 	--volume $${PWD}/bandc/apps/agenda/tests/samples:/app/bandc/apps/agenda/tests/samples:ro \
 	${IMAGE} \
 	convert \
-	"./bandc/apps/agenda/tests/samples/edims_354309.pdf[0]" \
+	"./bandc/apps/agenda/tests/samples/document_559F43E9-A324-12E8-80CA01C0F02507A7.pdf[0]" \
 	-thumbnail 400x400 \
 	-flatten \
 	jpg:- > docker-converttest.jpg


### PR DESCRIPTION
This project is heavily dependent upon imagemagick and ghostscript. Make sure CI can catch production issues.

```
make docker/build
make docker/test # tests run and pass
make docker/converttest # PDF is generated
make docker/run # site loads