### PR TITLE
chore: reduce tty noise in tests

### DIFF
--- a/bandc/apps/agenda/tests/test_pdf.py
+++ b/bandc/apps/agenda/tests/test_pdf.py
@@ -1,6 +1,9 @@
 import pathlib
 import unittest
+import warnings
 from unittest.mock import patch
+
+from pdfminer.pdfpage import PDFTextExtractionNotAllowedWarning
 
 from ..factories import DocumentFactory
 from ..pdf import _get_pdf_page_count, _grab_pdf_thumbnail, process_pdf
@@ -15,7 +18,9 @@ class PdfTest(unittest.TestCase):
 
     def test_get_pdf_page_count_handles_pdftextextractionnotallowed(self):
         filepath = BASE_DIR / "samples/edims_333704.pdf"
-        self.assertEqual(_get_pdf_page_count(filepath), 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDFTextExtractionNotAllowedWarning)
+            self.assertEqual(_get_pdf_page_count(filepath), 1)
 
     @patch("bandc.apps.agenda.pdf._grab_pdf_thumbnail")
     @patch("bandc.apps.agenda.pdf._download_document_pdf")
@@ -27,7 +32,9 @@ class PdfTest(unittest.TestCase):
             edims_id=333704,
         )
 
-        process_pdf(doc)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDFTextExtractionNotAllowedWarning)
+            process_pdf(doc)
         doc.refresh_from_db()
 
         self.assertEqual(doc.scrape_status, "scraped")

--- a/bandc/apps/agenda/tests/test_pdf.py
+++ b/bandc/apps/agenda/tests/test_pdf.py
@@ -43,13 +43,15 @@ class PdfTest(unittest.TestCase):
             edims_id=334453,
         )
 
-        process_pdf(doc)
+        with self.assertLogs("bandc.apps.agenda.pdf", level="ERROR"):
+            process_pdf(doc)
         doc.refresh_from_db()
 
         self.assertEqual(doc.scrape_status, "error")
         self.assertEqual(doc.text, "")
 
     def test_grab_pdf_thumbnail(self):
-        out = _grab_pdf_thumbnail(BASE_DIR / "samples/edims_334453.pdf")
+        with self.assertLogs("bandc.apps.agenda.pdf", level="INFO"):
+            out = _grab_pdf_thumbnail(BASE_DIR / "samples/edims_334453.pdf")
         self.assertIn(b"JFIF", out[:10])
         self.assertTrue(len(out) > 20_000)

--- a/bandc/apps/agenda/tests/test_utils.py
+++ b/bandc/apps/agenda/tests/test_utils.py
@@ -68,7 +68,8 @@ class UtilsTests(TestCase):
         # Sanity check
         self.assertEqual(bandc.latest_meeting, None)
 
-        process_next = _save_page(meeting_data, doc_data, bandc)
+        with self.assertLogs("bandc.apps.agenda.utils", level="INFO"):
+            process_next = _save_page(meeting_data, doc_data, bandc)
 
         self.assertFalse(process_next)
         self.assertEqual(bandc.latest_meeting.date.isoformat(), "2014-02-03")
@@ -81,7 +82,8 @@ class UtilsTests(TestCase):
         # Sanity check
         self.assertEqual(bandc.latest_meeting, None)
 
-        process_next = _save_page(meeting_data, doc_data, bandc)
+        with self.assertLogs("bandc.apps.agenda.utils", level="INFO"):
+            process_next = _save_page(meeting_data, doc_data, bandc)
 
         self.assertFalse(process_next)
         self.assertEqual(bandc.latest_meeting, None)
@@ -96,7 +98,8 @@ class UtilsTests(TestCase):
         self.assertEqual(bandc.latest_meeting, None)
 
         with scrape_logger.init() as context:
-            _save_page(meeting_data, doc_data, bandc)
+            with self.assertLogs("bandc.apps.agenda.utils", level="INFO"):
+                _save_page(meeting_data, doc_data, bandc)
 
             self.assertEqual(len(context.meetings), 7)
             self.assertEqual(len(context.documents), 28)

--- a/bandc/apps/agenda/tests/test_utils.py
+++ b/bandc/apps/agenda/tests/test_utils.py
@@ -35,28 +35,34 @@ class UtilsTests(TestCase):
             self.assertEqual(clean_text(input), expected)
 
     def test_process_page_works(self):
-        html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
+        with open(os.path.join(BASE_DIR, "samples/music.html")) as fh:
+            html = fh.read()
         meeting_data, doc_data = process_page(html)
         self.assertEqual(len(meeting_data), 7)
         self.assertEqual(len(doc_data), 28)
         self.assertEqual(doc_data[0]["date"], datetime.date(2014, 12, 1))
 
     def test_process_page_works_with_strong_elem(self):
-        html = open(os.path.join(BASE_DIR, "samples/2016_134_1.htm")).read()
+        with open(os.path.join(BASE_DIR, "samples/2016_134_1.htm")) as fh:
+            html = fh.read()
         meeting_data, doc_data = process_page(html)
         self.assertEqual(len(meeting_data), 5)
         self.assertEqual(len(doc_data), 16)
         self.assertEqual(doc_data[0]["date"], datetime.date(2016, 5, 19))
 
     def test_get_number_of_pages_works(self):
-        html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
+        with open(os.path.join(BASE_DIR, "samples/music.html")) as fh:
+            html = fh.read()
         self.assertEqual(get_number_of_pages(html), 1)
-        html = open(os.path.join(BASE_DIR, "samples/parks.html")).read()
+
+        with open(os.path.join(BASE_DIR, "samples/parks.html")) as fh:
+            html = fh.read()
         self.assertEqual(get_number_of_pages(html), 5)
 
     @mock.patch("bandc.apps.agenda.models.Document.refresh")
     def test_save_page_works(self, mock_task):
-        html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
+        with open(os.path.join(BASE_DIR, "samples/music.html")) as fh:
+            html = fh.read()
         meeting_data, doc_data = process_page(html)
         bandc = BandCFactory()
         # Sanity check
@@ -82,7 +88,8 @@ class UtilsTests(TestCase):
 
     @mock.patch("bandc.apps.agenda.models.Document.refresh")
     def test_save_page_logs_to_scrape_logger(self, mock_task):
-        html = open(os.path.join(BASE_DIR, "samples/music.html")).read()
+        with open(os.path.join(BASE_DIR, "samples/music.html")) as fh:
+            html = fh.read()
         meeting_data, doc_data = process_page(html)
         bandc = BandCFactory()
         # Sanity check


### PR DESCRIPTION
There' s still a `PDFTextExtractionNotAllowedWarning` but I'll ignore that for now