### PR TITLE
chore: switch from wsgi/waitress to asgi/granicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG GIT_SHA
 EXPOSE 8000
 HEALTHCHECK CMD nc -z localhost 8000
 ENV GIT_SHA=${GIT_SHA}
-CMD [".venv/bin/waitress-serve", "--port=8000", "bandc.wsgi:application"]
+CMD [".venv/bin/granian", "--interface", "asginl", "--host", "0.0.0.0", "--port", "8000", "bandc.asgi:application"]
 
 FROM base AS test
 RUN /app/.venv/bin/pip install '.[dev]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "project-runpy==1.1.2",
   "pdfminer.six==20201018",
   "sh==2.2.2",
-  "waitress==1.4.4",
   "sentry-sdk[django]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "dj-obj-update==0.6.*",
   "django-extensions==3.2.*",
   "django-object-actions==4.*",
+  "granian",
   "pillow==10.2.*",
   "lxml==5.*",
   "python-dateutil==2.8.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,9 @@ chardet==4.0.0
     # via
     #   pdfminer-six
     #   requests
-cryptography==44.0.1
+click==8.1.8
+    # via granian
+cryptography==44.0.2
     # via pdfminer-six
 dj-database-url==0.5.0
     # via atx-bandc (pyproject.toml)
@@ -26,6 +28,8 @@ django==5.1.6
 django-extensions==3.2.3
     # via atx-bandc (pyproject.toml)
 django-object-actions==4.3.0
+    # via atx-bandc (pyproject.toml)
+granian==1.7.6
     # via atx-bandc (pyproject.toml)
 idna==2.10
     # via requests
@@ -57,5 +61,7 @@ urllib3==1.26.20
     # via
     #   requests
     #   sentry-sdk
+uvloop==0.21.0
+    # via granian
 waitress==1.4.4
     # via atx-bandc (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,5 +63,3 @@ urllib3==1.26.20
     #   sentry-sdk
 uvloop==0.21.0
     # via granian
-waitress==1.4.4
-    # via atx-bandc (pyproject.toml)


### PR DESCRIPTION
Using `asginl` instead of `asgi` because:
```
[WARNING] ASGI Lifespan errored, continuing without Lifespan support (to avoid Lifespan completely use "asginl" interface)
```

https://github.com/emmett-framework/granian

closes #77