### PR TITLE
fix UNIQUE constraint failed: agenda_document.edims_id

### DIFF
--- a/bandc/apps/agenda/tests/test_utils.py
+++ b/bandc/apps/agenda/tests/test_utils.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 
 from .. import scrape_logger
 from ..factories import BandCFactory
+from ..models import Document
 from ..utils import (
     MeetingCancelledError,
     _save_page,
@@ -97,6 +98,7 @@ class UtilsTests(TestCase):
         bandc = BandCFactory()
         with self.assertLogs("bandc.apps.agenda.utils", level="INFO"):
             _save_page(meeting_data, doc_data, bandc)
+        self.assertEqual(Document.objects.filter(active=True).count(), 100)
 
         for row in doc_data:
             row["url"] = row["url"].replace(
@@ -105,6 +107,8 @@ class UtilsTests(TestCase):
 
         with self.assertLogs("bandc.apps.agenda.utils", level="INFO"):
             _save_page(meeting_data, doc_data, bandc)
+        # Assert stale_documents did not actually change anything
+        self.assertEqual(Document.objects.filter(active=True).count(), 100)
 
     @mock.patch("bandc.apps.agenda.models.Document.refresh")
     def test_save_page_logs_to_scrape_logger(self, mock_task):

--- a/bandc/apps/agenda/utils.py
+++ b/bandc/apps/agenda/utils.py
@@ -157,14 +157,16 @@ def _save_page(meeting_data, doc_data, bandc: BandC) -> bool:
         if doc.scrape_status == "toscrape":
             doc.refresh()
 
-    # Look for stale documents
+    # Archive documents from previously scraped meetings not found in this scrape
     stale_documents: list[str] = []
     for meeting in meetings.values():
         stale_documents.extend(meeting["docs"])
 
     # Deal with stale documents
     if stale_documents:
-        print("These docs are stale:", stale_documents)
+        logger.info(
+            "These %s docs are stale: %s", len(stale_documents), stale_documents
+        )
         Document.objects.filter(url__in=stale_documents).update(active=False)
 
     return False  # TODO


### PR DESCRIPTION
Fixes the IntegrityError:

    UNIQUE constraint failed: agenda_document.edims_id

Caused by the site changing url formats over time so the same PDF can show under multiple urls. Fixed a lazy way, but I'm too tired.